### PR TITLE
Fixes fork bug, small efficiency fix on change arguments.

### DIFF
--- a/SimpleShell/main.c
+++ b/SimpleShell/main.c
@@ -115,6 +115,7 @@ int execute(char **args){
 	} else if(pid == 0){		//Is child process
 		if(execvp(args[0], args) == -1){
 			printf("ssl: Couldn't execute program\n");
+			exit(0);
 		}
 	}
 

--- a/SimpleShell/main.c
+++ b/SimpleShell/main.c
@@ -97,16 +97,14 @@ int shell_process_line(char **args){
 /* Moves the arguments forward so it can be passed to function run to execute with the correct 
  * program arguments */
 
- char **change_args(char **args){
-	 int i = 0;
-	 for(i = 0; i < 32; i++){
-		 args[i] = args[i + 1];
-		 if(args[i] == NULL){
-			 break;
-		 }
-	 }
-	 return args;
- }
+char **change_args(char **args){
+	if (*args == NULL){
+		return args;
+	}
+	else{
+		return args + 1;
+	}
+}
 
 int execute(char **args){
 
@@ -167,4 +165,4 @@ char **readline(void){
 	args[count] = NULL;
 
 	return args;
-}	
+}


### PR DESCRIPTION
I encountered a problem with child processes not terminating when the fork, exec failed and living on as duplicates of the parent.
```bash
miravalier:~/Projects/SimpleShell$ ./ssl_dev
Simple Shell. Version: 0.1. Thomas Young (c) 2019
A Young Enterprise Application.
>asdf
ssl: Couldn't execute program
>asdf
ssl: Couldn't execute program
>asdf
ssl: Couldn't execute program
>exit
------------------------------------------------------------
>exit
------------------------------------------------------------
>exit
------------------------------------------------------------
>exit
------------------------------------------------------------
miravalier:~/Projects/SimpleShell$
```
The fix for that was to have the child process call exit in event of failure to exec.

The only other thing I changed was a small efficiency fix in a seemingly unused function, `change_args`